### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js binary


### PR DESCRIPTION
Fixes #14 

Treats .js-files as binaries so pushing artifacts to gh-pages-branch does not alter line endings in the files. 